### PR TITLE
[FIX] Make flag parameter optional to avoid AOT break

### DIFF
--- a/src/ui-switch.component.ts
+++ b/src/ui-switch.component.ts
@@ -148,7 +148,7 @@ export class UiSwitchComponent implements ControlValueAccessor {
   defaultBgColor: string = '#fff';
   defaultBoColor: string = '#dfdfdf';
 
-  getColor(flag) {
+  getColor(flag?) {
     if (flag === 'borderColor') return this.defaultBoColor;
     if (flag === 'switchColor') {
       if (this.reverse) return !this.checked ? this.switchColor : this.switchOffColor || this.switchColor;


### PR DESCRIPTION
AOT compilation breaks because getColor() in the templeate doesn't match the function signature. This should fix the issue.