### PR TITLE
[FIX] : ng build failed 

### DIFF
--- a/src/ui-switch.component.ts
+++ b/src/ui-switch.component.ts
@@ -148,7 +148,7 @@ export class UiSwitchComponent implements ControlValueAccessor {
   defaultBgColor: string = '#fff';
   defaultBoColor: string = '#dfdfdf';
 
-  getColor(flag) {
+  getColor(flag?:any) {
     if (flag === 'borderColor') return this.defaultBoColor;
     if (flag === 'switchColor') {
       if (this.reverse) return !this.checked ? this.switchColor : this.switchOffColor || this.switchColor;

--- a/src/ui-switch.component.ts
+++ b/src/ui-switch.component.ts
@@ -148,7 +148,7 @@ export class UiSwitchComponent implements ControlValueAccessor {
   defaultBgColor: string = '#fff';
   defaultBoColor: string = '#dfdfdf';
 
-  getColor(flag?:any) {
+  getColor(flag?:string) {
     if (flag === 'borderColor') return this.defaultBoColor;
     if (flag === 'switchColor') {
       if (this.reverse) return !this.checked ? this.switchColor : this.switchOffColor || this.switchColor;


### PR DESCRIPTION
getColor(flag) become getColor(flag?:string) 
```
ng buil --prod
C:/app/{Project_Name}/src/$$_gendir/node_modules/angular2-ui-switch/src/ui-switch.component.ngfactory.ts (238,28): Supplied parameters do not match any signature of call target.
```